### PR TITLE
Added power support for the travis.yml file with ppc64le. and update go versions for package: syllables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ arch:
 - amd64
 - ppc64le
 go:
-  - 1.5
-  - 1.6
-  - 1.7
+  - 1.13
+  - 1.14
+  - 1.15
   - tip
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch: 
+- amd64
+- ppc64le
 go:
   - 1.5
   - 1.6


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing.

updated the go version go:1.13, 1.14 and 1.15

